### PR TITLE
swap which user is provided in response when rock and pebbles are dis…

### DIFF
--- a/app/graphql/mutations/rock_and_pebbles/discontinue_rock_pebble_relationship.rb
+++ b/app/graphql/mutations/rock_and_pebbles/discontinue_rock_pebble_relationship.rb
@@ -15,12 +15,11 @@ module Mutations
             .where(active: true)
             .first
         send_pebble_email(rock_and_pebble, attributes)
-
         rock_and_pebble.update(active: false)
         if attributes[:user_relationship] == "pebble"
-          User.find_by(id: attributes[:rock_id])
-        else
           User.find_by(id: attributes[:pebble_id])
+        else
+          User.find_by(id: attributes[:rock_id])
         end
       end
 


### PR DESCRIPTION
…continued

### Sidebar Checklist

- [ ] Request reviewers
- [ ] Assign yourself and other contributors
- [ ] Link to project

### Issues Resolved
Resolves #

### Problem Addressed
Fix ruby version and dependencies to get app running again
swap which user data we're querying when displaying user info in order to provide the right user's info after discontinuing rock and pebble relationships

### Solution Implemented

### Other Notes
